### PR TITLE
dbdev brew formula update for version v0.1.7

### DIFF
--- a/dbdev.rb
+++ b/dbdev.rb
@@ -4,21 +4,21 @@
 class Dbdev < Formula
   desc "Dbdev CLI"
   homepage "https://database.dev/"
-  version "0.1.6"
+  version "0.1.7"
   license "MIT"
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://github.com/supabase/dbdev/releases/download/v0.1.6/dbdev-v0.1.6-macos-amd64.tar.gz"
-      sha256 "64d2aaba1e57383a9ca5fc0cdaf4ccc8d499ca19cf07270f0c3cda4383dbbfbc"
+      url "https://github.com/supabase/dbdev/releases/download/v0.1.7/dbdev-v0.1.7-macos-amd64.tar.gz"
+      sha256 "ad6aee6bbc8a2f6d447b90c80b7b9b5862ea9497cb21d8df39d023486cec1690"
 
       def install
         bin.install "dbdev"
       end
     end
     if Hardware::CPU.intel?
-      url "https://github.com/supabase/dbdev/releases/download/v0.1.6/dbdev-v0.1.6-macos-amd64.tar.gz"
-      sha256 "64d2aaba1e57383a9ca5fc0cdaf4ccc8d499ca19cf07270f0c3cda4383dbbfbc"
+      url "https://github.com/supabase/dbdev/releases/download/v0.1.7/dbdev-v0.1.7-macos-amd64.tar.gz"
+      sha256 "ad6aee6bbc8a2f6d447b90c80b7b9b5862ea9497cb21d8df39d023486cec1690"
 
       def install
         bin.install "dbdev"
@@ -28,16 +28,16 @@ class Dbdev < Formula
 
   on_linux do
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/supabase/dbdev/releases/download/v0.1.6/dbdev-v0.1.6-linux-arm64.tar.gz"
-      sha256 "7dc3a31aba324fd8796ebed3c50da11c4477da64412fb2b5aa71e8d2a3100b3f"
+      url "https://github.com/supabase/dbdev/releases/download/v0.1.7/dbdev-v0.1.7-linux-arm64.tar.gz"
+      sha256 "26654f66ec42d23d29e0953a84083daa48a9b70c69553b9184ac6a635bcab724"
 
       def install
         bin.install "dbdev"
       end
     end
     if Hardware::CPU.intel?
-      url "https://github.com/supabase/dbdev/releases/download/v0.1.6/dbdev-v0.1.6-linux-amd64.tar.gz"
-      sha256 "b32925e1f215ad6c71af153399775d44c0b2959257513514893241ad198a9d12"
+      url "https://github.com/supabase/dbdev/releases/download/v0.1.7/dbdev-v0.1.7-linux-amd64.tar.gz"
+      sha256 "c67f7477ed6e2ac272207c33c60a9cc839605f6e4edd1187ccad983fb269c106"
 
       def install
         bin.install "dbdev"


### PR DESCRIPTION
Automated update of Homebrew formula for dbdev v0.1.7.

This PR was generated by the dbdev release workflow.
Includes updated SHA256 checksums for macOS amd64, Linux amd64, and Linux arm64.
