### PR TITLE
fix: correct v2.107.0 sha256 checksums

### DIFF
--- a/Formula/supabase.rb
+++ b/Formula/supabase.rb
@@ -7,20 +7,20 @@ class Supabase < Formula
   on_macos do
     if Hardware::CPU.arm?
       url "https://github.com/supabase/cli/releases/download/v2.107.0/supabase_2.107.0_darwin_arm64.tar.gz"
-      sha256 "1f3ebf78a7080a0e684bfa83611548d903a82ce9c5bcdedf4f7fb4e87cb7348a"
+      sha256 "edcd58818414834f1a9e8acc89063b292defb6e41e3494287a9a2a6e0c150e0a"
     else
       url "https://github.com/supabase/cli/releases/download/v2.107.0/supabase_2.107.0_darwin_amd64.tar.gz"
-      sha256 "230d26dc50268a24013ec4260e16b35364615d8bfde403a235a34a3a2df85ce6"
+      sha256 "1c2bbcbd730e70d00533219e623b1a848aa8ada7d5a7b6184d755379824677b6"
     end
   end
 
   on_linux do
     if Hardware::CPU.arm?
       url "https://github.com/supabase/cli/releases/download/v2.107.0/supabase_2.107.0_linux_arm64.tar.gz"
-      sha256 "4d6a2153b7732ac6a8e69da49643423e67b9e07b8a5a4dfdcfb39c8438644421"
+      sha256 "d54648dd7f46ab824ba483bf4db712235a58c3242c2ff675ac7732a9b4f21e0f"
     else
       url "https://github.com/supabase/cli/releases/download/v2.107.0/supabase_2.107.0_linux_amd64.tar.gz"
-      sha256 "3ac074ce400670ac51d78168f3e8f67726edb1769480a613370cb19ee17f7fa9"
+      sha256 "ea233b337be698cee5bbca0795ee3e63b9dd154948c515c03cb72f191b3d103c"
     end
   end
 


### PR DESCRIPTION
## What changed

Replaces all four `sha256` values in `Formula/supabase.rb` for v2.107.0 with the checksums from the release `checksums.txt`.

| platform | sha256 |
|---|---|
| darwin_arm64 | `edcd58818414834f1a9e8acc89063b292defb6e41e3494287a9a2a6e0c150e0a` |
| darwin_amd64 | `1c2bbcbd730e70d00533219e623b1a848aa8ada7d5a7b6184d755379824677b6` |
| linux_arm64 | `d54648dd7f46ab824ba483bf4db712235a58c3242c2ff675ac7732a9b4f21e0f` |
| linux_amd64 | `ea233b337be698cee5bbca0795ee3e63b9dd154948c515c03cb72f191b3d103c` |

## Why

`brew install supabase/tap/supabase` failed for 2.107.0 because the formula carried SHA-256 values that match no released artifact. The downloads are legit — the metadata was wrong. The publish step computed checksums from the `build-blacksmith` build, but the GitHub Release ships the `build-github` build, and Bun binaries are not byte-for-byte reproducible across runners.

The corrected values were verified against the release `checksums.txt` and by hashing the exact artifacts users download. URLs and `version "2.107.0"` were already correct and are unchanged.

The pipeline root-cause fix (preventing this on future releases) is tracked separately in `supabase/cli`; this PR is the one-file remediation for the live 2.107.0 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RN3jAPQqsRnuzgYugDSazd

---
_Generated by [Claude Code](https://claude.ai/code/session_01RN3jAPQqsRnuzgYugDSazd)_